### PR TITLE
Refactor: update api link for gdg groups

### DIFF
--- a/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 
 
-private const val BASE_URL = "https://developers.google.com/community/gdg/directory/"
+private const val BASE_URL = "https://developers.google.com/community/gdg/groups/"
 interface GdgApiService {
     @GET("directory.json")
     fun getChapters():


### PR DESCRIPTION
The value/link for `BASE_URL` which was https://developers.google.com/community/gdg/directory/directory.json would return an error 404. The new value/link should be https://developers.google.com/community/gdg/groups/directory.json