### PR TITLE
Updated AndroidManifest.xml with hardwareAccelerated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:supportsRtl="true"
+            android:hardwareAccelerated="false"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:theme="@style/AppTheme"
             tools:ignore="AllowBackup,GoogleAppIndexingWarning">


### PR DESCRIPTION
Added hardware accelerated attribute to false in AndroidManifest.xml.

If running on the device, "Canvas: trying to draw too large bitmap.”