### PR TITLE
Update Incorrect community URL

### DIFF
--- a/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
+++ b/app/src/main/java/com/example/android/gdgfinder/network/GdgApiService.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
 
 
-private const val BASE_URL = "https://developers.google.com/community/gdg/directory/"
+private const val BASE_URL = "https://developers.google.com/community/gdg/groups/"
 interface GdgApiService {
     @GET("directory.json")
     fun getChapters():


### PR DESCRIPTION
The Google developers community URL changed and caused the app to crash after a navigation to `GdgListFragment`

Fixes #13